### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/src/HTTPC.jl
+++ b/src/HTTPC.jl
@@ -133,7 +133,7 @@ function curl_read_cb(out::Ptr{Void}, s::Csize_t, n::Csize_t, p_ctxt::Ptr{Void})
 
     if (ctxt.rd.typ == :buffer)
         ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint),
-                out, convert(Ptr{Uint8}, ctxt.rd.str) + ctxt.rd.offset, b2copy)
+                out, convert(Ptr{Uint8}, pointer(ctxt.rd.str)) + ctxt.rd.offset, b2copy)
     elseif (ctxt.rd.typ == :io)
         b_read = read(ctxt.rd.src, Uint8, b2copy)
         ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint), out, b_read, b2copy)
@@ -477,7 +477,7 @@ function _put_post(url::String, putorpost::Symbol, options::RequestOptions, rd::
 
             @ce_curl curl_easy_setopt CURLOPT_READFUNCTION c_curl_read_cb
         else
-            ppostdata = pointer(convert(Array{Uint8}, rd.str), 1)
+            ppostdata = pointer(rd.str)
             @ce_curl curl_easy_setopt CURLOPT_COPYPOSTFIELDS ppostdata
         end
 


### PR DESCRIPTION
There's a couple more that seem to be coming from the wrapped calls, but I'm puzzled why because  the `@c` macro doesn't explicitly use `convert`.

```
WARNING: convert{T}(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead.
 in convert at deprecated.jl:26
 in exec_as_multi at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:670
 in _put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:484
 in put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:454
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:388
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:527
 in include_from_node1 at loading.jl:120
WARNING: convert{T}(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead.
 in convert at deprecated.jl:26
 in exec_as_multi at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:673
 in _put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:484
 in put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:454
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:388
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:527
 in include_from_node1 at loading.jl:120
WARNING: convert{T}(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead.
 in convert at deprecated.jl:26
 in process_response at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:202
 in exec_as_multi at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:704
 in _put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:484
 in put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:454
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:388
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:527
 in include_from_node1 at loading.jl:120
WARNING: convert{T}(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead.
 in convert at deprecated.jl:26
 in process_response at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:202
 in exec_as_multi at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:704
 in _put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:484
 in put_post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:454
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:388
 in post at /home/ihnorton/.julia/v0.3/HTTPClient/src/HTTPC.jl:527
 in include_from_node1 at loading.jl:120
```
