### PR TITLE
Fix tuple param handling in 0.4.0

### DIFF
--- a/src/HTTPC.jl
+++ b/src/HTTPC.jl
@@ -426,7 +426,7 @@ function put_post(url::AbstractString, data, putorpost::Symbol, options::Request
         rd.sz = length(data)
 
     elseif isa(data, Dict) || (isa(data, Vector) && issubtype(eltype(data), Tuple))
-        arr_data = isa(data, Dict) ? collect(data) : data
+        arr_data = isa(data, Dict) ? Array{Tuple,1}(map((d) -> (d[1], d[2]), data)) : data
         rd.str = urlencode_query_params(arr_data)  # Not very optimal since it creates another curl handle, but it is clean...
         rd.sz = length(rd.str)
         rd.typ = :buffer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,11 +45,11 @@ r=HTTPC.get(HB * "/cookies/set?k1=v1&k2=v2")
 @test Set(r.headers["Set-Cookie"]) == Set(["k1=v1; Path=/", "k2=v2; Path=/"])
 println("Test.headers passed")
 
-r=HTTPC.get(RB, RequestOptions(query_params=collect(@compat Dict(:test => 1.1, :Hello => "\"World\"", "_rt" => "&!@#%"))))
+r=HTTPC.get(RB, RequestOptions(query_params=[(:test, 1.1), (:Hello, "\"World\""), ("_rt", "&!@#%")]))
 @test r.http_code == 200
 println("Test 1.1 passed, http_code : " * string(r.http_code))
 
-rr=HTTPC.get(RB, RequestOptions(query_params=collect(@compat Dict(:test => 1.2, :Hello => "\"World\"", "_rt" => "&!@#%")), blocking=false))
+rr=HTTPC.get(RB, RequestOptions(query_params=[(:test, 1.1), (:Hello, "\"World\""), ("_rt", "&!@#%")], blocking=false))
 r = fetch(rr)
 @test r.http_code == 200
 println("Test 1.2 passed, http_code : " * string(r.http_code))
@@ -193,4 +193,3 @@ trigger = :go
 for ref in rrefs
     wait(ref)
 end
-


### PR DESCRIPTION
Simply calling "collect" on a dictionary causes compatibility problems. I changed the tests to use a tuple array literal in RequestOptions, and improved Dict handling in the post function.