### PR TITLE
Fix macro in Julia v0.6 with esc

### DIFF
--- a/src/HTTPC.jl
+++ b/src/HTTPC.jl
@@ -208,7 +208,7 @@ c_curl_multi_timer_cb = cfunction(curl_multi_timer_cb, Cint, (Ptr{Void}, Clong, 
 macro ce_curl(f, args...)
     quote
         cc = CURLE_OK
-        cc = $(esc(f))(ctxt.curl, $(args...))
+        cc = $(esc(f))($(esc(:ctxt)).curl, $(esc.(args)...))
 
         if(cc != CURLE_OK)
             error(string($f) * "() failed: " * unsafe_string(curl_easy_strerror(cc)))
@@ -219,7 +219,7 @@ end
 macro ce_curlm(f, args...)
     quote
         cc = CURLM_OK
-        cc = $(esc(f))(curlm, $(args...))
+        cc = $(esc(f))($(esc(:curlm)), $(esc.(args)...))
 
         if(cc != CURLM_OK)
             error(string($f) * "() failed: " * unsafe_string(curl_multi_strerror(cc)))


### PR DESCRIPTION
Currently, on Julia v0.6, when I do `get` I get
```julia
ERROR: UndefVarError: ctxt not defined
Stacktrace:
 [1] setup_easy_handle(::String, ::HTTPClient.HTTPC.RequestOptions) at /home/blegat/.julia/v0.6/HTTPClient/src/HTTPC.jl:211
 [2] get(::String, ::HTTPClient.HTTPC.RequestOptions) at /home/blegat/.julia/v0.6/HTTPClient/src/HTTPC.jl:382
 [3] #get#7(::Array{Any,1}, ::Function, ::String) at /home/blegat/.julia/v0.6/HTTPClient/src/HTTPC.jl:534
```
This change fixes this issue